### PR TITLE
wordcloudのリンクを追加、requirementの修正

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Django==5.0.3
 Faker==24.11.0
 fonttools==4.49.0
 idna==3.6
+Janome==0.5.0
 kiwisolver==1.4.5
 matplotlib==3.8.3
 numpy==1.26.4

--- a/sampleApp/templates/dashboard.html
+++ b/sampleApp/templates/dashboard.html
@@ -33,6 +33,10 @@
                         </div>
                         <button type="submit" class="btn btn-primary">更新</button>
                     </form>
+                    <!-- ここにWordCloudのリンクを追加 -->
+                    <div class="mt-4">
+                        <button onclick="window.location.href='{% url 'wordcloud' %}'" class="btn btn-secondary btn-block">WordCloudを表示</button>
+                    </div>
                 </div>
             </nav>
 


### PR DESCRIPTION
dashboardのテンプレートにwordcloudを表示させるボタンの追加
wordcloudの実装でjanomeをインストールしたので、requirementに追加。
（fontpathのもとになるものもインストールしたが、pip freezeには表示されなかった）