### PR TITLE
fix2 wordcloud

### DIFF
--- a/sampleApp/templates/dashboard.html
+++ b/sampleApp/templates/dashboard.html
@@ -35,7 +35,7 @@
                     </form>
                     <!-- ここにWordCloudのリンクを追加 -->
                     <div class="mt-4">
-                        <button onclick="window.location.href='{% url 'wordcloud' %}'" class="btn btn-secondary btn-block">WordCloudを表示</button>
+                        <a href="{% url 'wordcloud' %}" class="btn btn-secondary btn-block">WordCloudを表示</a>
                     </div>
                 </div>
             </nav>


### PR DESCRIPTION
dashboard内で不要なjavascriptを使用していたので変更
変更前
<button onclick="window.location.href='{% url 'wordcloud' %}'" class="btn btn-secondary btn-block">WordCloudを表示</button>

変更後
 <a href="{% url 'wordcloud' %}" class="btn btn-secondary btn-block">WordCloudを表示</a>