### PR TITLE
dockerfileとrequiremnts.txtの変更

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,20 @@
-FROM python:3 
-ENV PYTHONUNBUFFERED 1 
-RUN pip install django
-RUN pip install psycopg2
+# ベースイメージの指定
+FROM python:3
 
-RUN pip install --upgrade deepl
+# 環境変数の設定
+ENV PYTHONUNBUFFERED 1
+
+# 作業ディレクトリを作成し、そこに移動
+WORKDIR /app
+
+# requirements.txt をコンテナにコピー
+COPY requirements.txt .
+
+# パッケージのインストール
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 残りのアプリケーションファイルをコンテナにコピー
+COPY . .
+
+# アプリケーションを起動するコマンド
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,6 @@ tzdata==2024.1
 urllib3==2.2.1
 wheel==0.42.0
 wordcloud==1.9.3
+django
+psycopg2
+deepl


### PR DESCRIPTION
既存のdockerfileだと、自動でrequirements.txtを読み取ってくれないため、dockerfileにコンテナ立ち上げ時にインストールするように入れ込んだ。また、それに伴い、dockerfileにインストール指示をしていたパッケージをrequiemnts.txtに移動。