### PR TITLE
base

### DIFF
--- a/sampleApp/templates/base4.html
+++ b/sampleApp/templates/base4.html
@@ -54,12 +54,12 @@
         {% endblock %}
     </header>
 
-    <main style="min-height: calc(100vh - 200px);"> <!-- コンテンツ領域が足りない場合も、フッターが重ならないようにする -->
+    <main style="min-height: calc(100vh - 200px); padding-bottom: 100px;"> <!-- 100pxの余白をフッターのために追加 -->
         {% block content %}
         {% endblock %}
     </main>
 
-    <footer id="page-footer" class="bg-dark text-white text-center p-4 w100"> <!-- position: fixed を削除 -->
+    <footer id="page-footer" class="bg-dark text-white text-center p-4 w100" style="height: 100px;"> <!-- 高さを明示的に設定 -->
         <div class="container">
             <div class="row">
                 <div class="col">


### PR DESCRIPTION
baseテンプレートでmainとfooterが重複するので、修正
main 要素に padding-bottom を追加: main に padding-bottom: 100px; を追加し、フッターの高さ分余白を確保しました。これにより、コンテンツが短い場合でもフッターと重ならず、余白が生まれます。

フッターの高さを指定: フッターに height: 100px; を指定しました。これにより、フッターの高さが固定され、見た目が整います。